### PR TITLE
Add RemoteUserLocalAuthenticator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,3 +25,11 @@ You should be able to start jupyterhub.  The "/remote_user_login" resource
 will look for the authenticated user name in the HTTP header "REMOTE_USER".
 If found, and not blank, you will be logged in as that user.
 
+Alternatively, you can use `RemoteUserLocalAuthenticator`::
+
+    c.JupyterHub.authenticator_class = 'remote_user.remote_user_auth.RemoteUserLocalAuthenticator'
+
+This provides the same authentication functionality but is derived from
+`LocalAuthenticator` and therefore provides features such as the ability
+to add local accounts through the admin interface if configured to do so.
+

--- a/remote_user/remote_user_auth.py
+++ b/remote_user/remote_user_auth.py
@@ -2,6 +2,7 @@
 import os
 from jupyterhub.handlers import BaseHandler
 from jupyterhub.auth import Authenticator
+from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.utils import url_path_join
 from tornado import gen, web
 from traitlets import Unicode
@@ -38,3 +39,23 @@ class RemoteUserAuthenticator(Authenticator):
     def authenticate(self, *args):
         raise NotImplementedError()
 
+
+class RemoteUserLocalAuthenticator(LocalAuthenticator):
+    """
+    Accept the authenticated user name from the REMOTE_USER HTTP header.
+    Derived from LocalAuthenticator for use of features such as adding
+    local accounts through the admin interface.
+    """
+    header_name = Unicode(
+        default_value='REMOTE_USER',
+        config=True,
+        help="""HTTP header to inspect for the authenticated username.""")
+
+    def get_handlers(self, app):
+        return [
+            (r'/login', RemoteUserLoginHandler),
+        ]
+
+    @gen.coroutine
+    def authenticate(self, *args):
+        raise NotImplementedError()


### PR DESCRIPTION
This patch adds RemoteUserLocalAuthenticator, which is the same as RemoteUserAuthenticator but derived from LocalAuthenticator.  This provides access to features of LocalAuthenticator such as the ability to add local accounts in the admin interface.
